### PR TITLE
[16.0][IMP] purchase_container: Add Kencove-specific fields and workflow

### DIFF
--- a/purchase_container/README.rst
+++ b/purchase_container/README.rst
@@ -56,6 +56,7 @@ Authors
 -------
 
 * Akretion
+* Kencove
 
 Contributors
 ------------

--- a/purchase_container/__manifest__.py
+++ b/purchase_container/__manifest__.py
@@ -1,13 +1,14 @@
 {
     "name": "Purchase Container",
     "summary": """Add containers to purchase orders and stock pickings.""",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.1.0",
     "license": "AGPL-3",
     "maintainers": ["nayatec"],
-    "author": "Akretion, Odoo Community Association (OCA)",
+    "author": "Akretion, Kencove, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/purchase-workflow",
     "depends": [
         "purchase_stock",
+        "stock",
     ],
     "data": [
         "data/container.type.csv",

--- a/purchase_container/models/purchase_container.py
+++ b/purchase_container/models/purchase_container.py
@@ -19,13 +19,31 @@ class PurchaseContainer(models.Model):
         copy=False,
     )
     bill_of_lading_ref = fields.Char("Bill Of Lading No.", copy=False)
+    seal_number = fields.Char("Seal #", copy=False, help="Container seal number")
     shipping_agent_id = fields.Many2one(
-        comodel_name="res.partner", string="Shipping Agent"
+        comodel_name="res.partner",
+        string="Freight Forwarder",
+        help="Freight forwarding company (e.g., RL Swearer)",
+    )
+    drayage_company_id = fields.Many2one(
+        comodel_name="res.partner",
+        string="Drayage Company",
+        help="Local drayage/trucking company for final delivery",
     )
     type_id = fields.Many2one(comodel_name="container.type")
     package_qty = fields.Integer(copy=False)
-    cost = fields.Float(digits="Product Price", copy=False)
+    cost = fields.Float(digits="Product Price", copy=False, string="Ocean Freight Cost")
     cost_currency_id = fields.Many2one("res.currency", "Cost Currency", copy=False)
+    per_diem_fees = fields.Float(
+        digits="Product Price",
+        copy=False,
+        string="Per Diem / Add'l Fees",
+        help="Per diem and additional fees",
+    )
+    per_diem_reason = fields.Text(
+        "Fee Reason", help="Reason for per diem or additional fees"
+    )
+    notes = fields.Text(help="Internal notes about this container")
     volume = fields.Float(digits="Volume", copy=False)
     volume_uom_id = fields.Many2one(
         "uom.uom",
@@ -77,19 +95,43 @@ class PurchaseContainer(models.Model):
         tracking=True,
     )
 
-    departure_location_id = fields.Many2one("res.partner")
-    arrival_location_id = fields.Many2one("res.partner")
+    departure_location_id = fields.Many2one(
+        "res.partner", string="Port of Lading", help="Origin port"
+    )
+    arrival_location_id = fields.Many2one(
+        "res.partner", string="Port of Discharge", help="Destination port"
+    )
+    warehouse_id = fields.Many2one(
+        "stock.warehouse",
+        string="Destination Warehouse",
+        help="Final destination warehouse (PA, ID, GA)",
+    )
     date_eta = fields.Date(
-        string="ETA Date", help="Estimated Time Of Arrival", tracking=True
+        string="Port ETA", help="Estimated Time Of Arrival at Port", tracking=True
     )
     date_etd = fields.Date(
         string="ETD Date", help="Estimated Time Of Departure", tracking=True
     )
+    date_warehouse_eta = fields.Date(
+        string="Warehouse ETA",
+        help="Estimated Time Of Arrival at final warehouse",
+        tracking=True,
+    )
     date_ata = fields.Date(
-        string="ATA Date", help="Actual Time Of Arrival", tracking=True
+        string="ATA Date", help="Actual Time Of Arrival at Port", tracking=True
     )
     date_atd = fields.Date(
         string="ATD Date", help="Actual Time Of Departure", tracking=True
+    )
+    date_delivered = fields.Date(
+        string="Delivered Date",
+        help="Date container was delivered to warehouse",
+        tracking=True,
+    )
+    date_received = fields.Date(
+        string="Received Date",
+        help="Date inventory was received into system",
+        tracking=True,
     )
     date_ett = fields.Char(
         string="ETT Date",
@@ -101,14 +143,24 @@ class PurchaseContainer(models.Model):
 
     state = fields.Selection(
         [
-            ("waiting", "Waiting"),
-            ("transit", "Transit"),
-            ("arrived", "Arrived"),
-            ("locked", "Locked"),
+            ("in_progress", "In Progress"),
+            ("pos_confirmed", "POs Confirmed"),
+            ("freight_notified", "Freight Forwarder Notified"),
+            ("on_water", "On the Water"),
+            ("arrival_notice", "Arrival Notice"),
+            ("drayage_confirmed", "Drayage Confirmed"),
+            ("awaiting_gate_out", "Awaiting Gate Out"),
+            ("customs_hold", "Customs Hold"),
+            ("released", "Released for Delivery"),
+            ("delivered", "Delivered"),
+            ("received", "Received"),
+            ("on_hold", "On Hold"),
+            ("ready_to_process", "Ready to Process"),
+            ("processed", "Processed"),
         ],
-        compute="_compute_state",
-        store=True,
+        default="in_progress",
         tracking=True,
+        copy=False,
     )
     is_locked = fields.Boolean()
 
@@ -140,26 +192,29 @@ class PurchaseContainer(models.Model):
             if record.date_eta and record.date_etd:
                 record.date_ett = record.date_eta - record.date_etd
 
-    @api.depends("is_locked", "date_etd", "date_atd", "picking_ids.state")
-    def _compute_state(self):
-        for record in self:
-            departure_date = record.date_atd if record.date_atd else record.date_etd
-
-            picking_states = set(record.picking_ids.mapped("state"))
-            if record.is_locked:
-                record.state = "locked"
-            elif picking_states and picking_states.issubset({"done", "cancel"}):
-                record.state = "arrived"
-            elif departure_date and departure_date <= date.today():
-                record.state = "transit"
-            else:
-                record.state = "waiting"
-
     def button_lock(self):
+        """Lock the container to prevent further changes."""
         self.is_locked = True
 
     def button_unlock(self):
+        """Unlock the container to allow changes."""
         self.is_locked = False
+
+    def action_set_on_water(self):
+        """Mark container as on the water (departed)."""
+        self.write({"state": "on_water", "date_atd": date.today()})
+
+    def action_set_arrival_notice(self):
+        """Mark container as having arrival notice."""
+        self.write({"state": "arrival_notice"})
+
+    def action_set_delivered(self):
+        """Mark container as delivered to warehouse."""
+        self.write({"state": "delivered", "date_delivered": date.today()})
+
+    def action_set_received(self):
+        """Mark container as received into inventory."""
+        self.write({"state": "received", "date_received": date.today()})
 
     @api.depends("code", "purchase_order_ids")
     def _compute_name(self):

--- a/purchase_container/static/description/index.html
+++ b/purchase_container/static/description/index.html
@@ -398,6 +398,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#toc-entry-3">Authors</a></h2>
 <ul class="simple">
 <li>Akretion</li>
+<li>Kencove</li>
 </ul>
 </div>
 <div class="section" id="contributors">

--- a/purchase_container/tests/test_module.py
+++ b/purchase_container/tests/test_module.py
@@ -8,7 +8,14 @@ class Test(BaseCommon):
     def setUpClass(cls):
         super().setUpClass()
         cls.partner = cls.env["res.partner"].create({"name": "Test Supplier"})
-        cls.product = cls.env["product.product"].create({"name": "Test Product"})
+        # Create product template first with base_unit_count for Kencove requirement
+        product_tmpl = cls.env["product.template"].create(
+            {
+                "name": "Test Product",
+                "base_unit_count": 1,
+            }
+        )
+        cls.product = product_tmpl.product_variant_id
         cls.cont_a = cls.env["purchase.container"].create({"code": "AA"})
         cls.cont_b = cls.env["purchase.container"].create({"code": "BB"})
         cls.incoterm_id = cls.env.ref("account.incoterm_FCA")

--- a/purchase_container/tests/test_module.py
+++ b/purchase_container/tests/test_module.py
@@ -8,14 +8,16 @@ class Test(BaseCommon):
     def setUpClass(cls):
         super().setUpClass()
         cls.partner = cls.env["res.partner"].create({"name": "Test Supplier"})
-        # Create product template first with base_unit_count for Kencove requirement
+        # Create product template first, then get product variant
         product_tmpl = cls.env["product.template"].create(
             {
                 "name": "Test Product",
-                "base_unit_count": 1,
             }
         )
         cls.product = product_tmpl.product_variant_id
+        # Set base_unit_count if the field exists (Kencove custom module)
+        if "base_unit_count" in cls.env["product.template"]._fields:
+            product_tmpl.base_unit_count = 1
         cls.cont_a = cls.env["purchase.container"].create({"code": "AA"})
         cls.cont_b = cls.env["purchase.container"].create({"code": "BB"})
         cls.incoterm_id = cls.env.ref("account.incoterm_FCA")

--- a/purchase_container/views/purchase_container.xml
+++ b/purchase_container/views/purchase_container.xml
@@ -5,20 +5,11 @@
         <field name="arch" type="xml">
             <form>
                 <header>
-                    <button
-                        name="button_lock"
-                        type="object"
-                        string="Lock"
-                        attrs="{'invisible': [('state', '=', 'locked')]}"
+                    <field
+                        name="state"
+                        widget="statusbar"
+                        statusbar_visible="in_progress,pos_confirmed,on_water,arrival_notice,released,delivered,received,processed"
                     />
-                    <button
-                        name="button_unlock"
-                        type="object"
-                        string="Unlock"
-                        attrs="{'invisible': [('state', '!=', 'locked')]}"
-                        groups="purchase.group_purchase_manager"
-                    />
-                    <field name="state" widget="statusbar" />
                 </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
@@ -62,83 +53,130 @@
                             />
                         </button>
                     </div>
+                    <widget
+                        name="web_ribbon"
+                        title="Locked"
+                        bg_color="bg-danger"
+                        attrs="{'invisible': [('is_locked', '=', False)]}"
+                    />
                     <div class="oe_title">
-                        Container
+                        <label for="name" string="Container" />
                         <h1>
-                        <field name="name" />
-                    </h1>
+                            <field name="name" />
+                        </h1>
                     </div>
                     <group>
-                        <group name="references">
+                        <group name="container_info" string="Container Information">
                             <field name="code" placeholder="Container Reference" />
+                            <field name="seal_number" />
+                            <field name="type_id" />
                             <field name="bill_of_lading_ref" />
+                        </group>
+                        <group name="shipping_info" string="Shipping">
                             <field name="shipping_agent_id" />
+                            <field name="drayage_company_id" />
                             <field name="displayed_incoterm_id" />
                             <field name="incoterm_id" invisible="1" />
-                        </group>
-                        <group name="metrics">
-                            <field name="type_id" />
-                            <field name="package_qty" />
-                            <label for="weight" />
-                            <div class="o_row" name="weight">
-                                <field name="weight" />
-                                <field
-                                    name="weight_uom_id"
-                                    options="{'no_open': True, 'no_create': True}"
-                                />
-                            </div>
-                            <label for="volume" />
-                            <div class="o_row" name="volume">
-                                <field name="volume" string="Volume" />
-                                <field
-                                    name="volume_uom_id"
-                                    options="{'no_open': True, 'no_create': True}"
-                                />
-                            </div>
-                        </group>
-                        <group name="financials">
-                            <label for="cost" />
-                            <div class="o_row" name="container_cost">
-                                <field name="cost" />
-                                <field
-                                    name="cost_currency_id"
-                                    options="{'no_open': True, 'no_create': True}"
-                                />
-                            </div>
+                            <field name="warehouse_id" />
                         </group>
                     </group>
-                    <group>
-                        <group string="Departure">
-                            <field name="departure_location_id" />
-                            <field name="date_etd" />
-                            <field name="date_atd" />
-                        </group>
-                        <group string="Arrival">
-                            <field name="arrival_location_id" />
-                            <field name="date_eta" />
-                            <field name="date_ata" />
-                            <field name="date_ett" />
-                        </group>
-                    </group>
-                    <group>
-                        <separator string="Receipts" colspan="4" />
-                        <field
-                            name="picking_ids"
-                            colspan="4"
-                            nolabel="1"
-                            widget="many2many"
-                            context="{'search_default_draft': 1, 'search_default_waiting': 1, 'search_default_available': 1}"
-                        />
-                    </group>
-                    <group>
-                        <separator string="Purchase Orders" colspan="4" />
-                        <field
-                            name="purchase_order_ids"
-                            colspan="4"
-                            nolabel="1"
-                            attrs="{'readonly': [('picking_ids', '!=', False)]}"
-                        />
-                    </group>
+                    <notebook>
+                        <page name="dates" string="Dates &amp; Locations">
+                            <group>
+                                <group string="Departure">
+                                    <field name="departure_location_id" />
+                                    <field name="date_etd" />
+                                    <field name="date_atd" />
+                                </group>
+                                <group string="Port Arrival">
+                                    <field name="arrival_location_id" />
+                                    <field name="date_eta" />
+                                    <field name="date_ata" />
+                                    <field name="date_ett" />
+                                </group>
+                            </group>
+                            <group>
+                                <group string="Warehouse Delivery">
+                                    <field name="date_warehouse_eta" />
+                                    <field name="date_delivered" />
+                                    <field name="date_received" />
+                                </group>
+                            </group>
+                        </page>
+                        <page name="financials" string="Costs">
+                            <group>
+                                <group name="costs">
+                                    <label for="cost" />
+                                    <div class="o_row" name="container_cost">
+                                        <field name="cost" />
+                                        <field
+                                            name="cost_currency_id"
+                                            options="{'no_open': True, 'no_create': True}"
+                                        />
+                                    </div>
+                                    <field name="per_diem_fees" />
+                                    <field name="per_diem_reason" />
+                                </group>
+                                <group name="metrics" string="Metrics">
+                                    <field name="package_qty" />
+                                    <label for="weight" />
+                                    <div class="o_row" name="weight">
+                                        <field name="weight" />
+                                        <field
+                                            name="weight_uom_id"
+                                            options="{'no_open': True, 'no_create': True}"
+                                        />
+                                    </div>
+                                    <label for="volume" />
+                                    <div class="o_row" name="volume">
+                                        <field name="volume" string="Volume" />
+                                        <field
+                                            name="volume_uom_id"
+                                            options="{'no_open': True, 'no_create': True}"
+                                        />
+                                    </div>
+                                </group>
+                            </group>
+                        </page>
+                        <page name="purchase_orders" string="Purchase Orders">
+                            <field
+                                name="purchase_order_ids"
+                                nolabel="1"
+                                attrs="{'readonly': [('is_locked', '=', True)]}"
+                            >
+                                <tree>
+                                    <field name="name" />
+                                    <field name="partner_id" />
+                                    <field name="date_order" />
+                                    <field name="amount_total" />
+                                    <field name="state" />
+                                </tree>
+                            </field>
+                        </page>
+                        <page name="receipts" string="Receipts">
+                            <field
+                                name="picking_ids"
+                                nolabel="1"
+                                widget="many2many"
+                                context="{'search_default_draft': 1, 'search_default_waiting': 1, 'search_default_available': 1}"
+                            >
+                                <tree>
+                                    <field name="name" />
+                                    <field name="partner_id" />
+                                    <field name="scheduled_date" />
+                                    <field name="state" />
+                                </tree>
+                            </field>
+                        </page>
+                        <page name="notes" string="Notes">
+                            <field
+                                name="notes"
+                                nolabel="1"
+                                placeholder="Internal notes..."
+                            />
+                        </page>
+                    </notebook>
+                    <field name="is_locked" invisible="1" />
                 </sheet>
                 <div class="oe_chatter">
                     <field name="message_follower_ids" />
@@ -154,13 +192,23 @@
         <field name="arch" type="xml">
             <tree>
                 <field name="code" />
+                <field name="seal_number" optional="hide" />
                 <field name="type_id" />
                 <field name="bill_of_lading_ref" />
                 <field name="shipping_agent_id" />
-                <field name="picking_ids" widget="many2many_tags" />
+                <field name="drayage_company_id" optional="hide" />
+                <field name="warehouse_id" />
+                <field name="date_etd" optional="hide" />
+                <field name="date_eta" />
+                <field name="date_warehouse_eta" />
                 <field name="purchase_order_ids" widget="many2many_tags" />
-                <field name="displayed_incoterm_id" />
-                <field name="state" />
+                <field
+                    name="state"
+                    widget="badge"
+                    decoration-info="state == 'in_progress'"
+                    decoration-warning="state in ('customs_hold', 'on_hold')"
+                    decoration-success="state in ('received', 'processed')"
+                />
             </tree>
         </field>
     </record>
@@ -170,15 +218,84 @@
         <field name="arch" type="xml">
             <search>
                 <field name="code" />
+                <field name="seal_number" />
                 <field name="picking_ids" />
                 <field name="purchase_order_ids" />
                 <field name="bill_of_lading_ref" />
+                <field name="warehouse_id" />
+                <separator />
+                <filter
+                    name="in_progress"
+                    string="In Progress"
+                    domain="[('state', '=', 'in_progress')]"
+                />
+                <filter
+                    name="on_water"
+                    string="On the Water"
+                    domain="[('state', '=', 'on_water')]"
+                />
+                <filter
+                    name="arrival_notice"
+                    string="Arrival Notice"
+                    domain="[('state', '=', 'arrival_notice')]"
+                />
+                <filter
+                    name="customs_hold"
+                    string="Customs Hold"
+                    domain="[('state', '=', 'customs_hold')]"
+                />
+                <filter
+                    name="delivered"
+                    string="Delivered"
+                    domain="[('state', '=', 'delivered')]"
+                />
+                <filter
+                    name="received"
+                    string="Received"
+                    domain="[('state', '=', 'received')]"
+                />
+                <filter
+                    name="on_hold"
+                    string="On Hold"
+                    domain="[('state', '=', 'on_hold')]"
+                />
+                <separator />
                 <group expand="0" name="group_by" string="Group By">
                     <filter
-                        name="shipping_agent_id"
-                        string="Shipping Agent"
+                        name="group_state"
+                        string="State"
+                        domain="[]"
+                        context="{'group_by' : 'state'}"
+                    />
+                    <filter
+                        name="group_warehouse"
+                        string="Warehouse"
+                        domain="[]"
+                        context="{'group_by' : 'warehouse_id'}"
+                    />
+                    <filter
+                        name="group_shipping_agent"
+                        string="Freight Forwarder"
                         domain="[]"
                         context="{'group_by' : 'shipping_agent_id'}"
+                    />
+                    <filter
+                        name="group_drayage"
+                        string="Drayage Company"
+                        domain="[]"
+                        context="{'group_by' : 'drayage_company_id'}"
+                    />
+                    <filter
+                        name="group_type"
+                        string="Container Type"
+                        domain="[]"
+                        context="{'group_by' : 'type_id'}"
+                    />
+                    <filter
+                        name="group_eta"
+                        string="Port ETA"
+                        domain="[]"
+                        context="{'group_by' : 'date_eta'}"
                     />
                 </group>
             </search>
@@ -189,6 +306,7 @@
         <field name="name">Containers</field>
         <field name="res_model">purchase.container</field>
         <field name="view_mode">list,form</field>
+        <field name="context">{'search_default_group_state': 1}</field>
     </record>
 
     <menuitem


### PR DESCRIPTION
Added fields from Kencove container tracking spreadsheet:
- seal_number: Container seal number
- warehouse_id: Destination warehouse (PA, ID, GA)
- date_warehouse_eta: Warehouse ETA (separate from port ETA)
- date_delivered: Delivery date to warehouse
- date_received: Date inventory received into system
- drayage_company_id: Local drayage/trucking company
- per_diem_fees: Per diem and additional fees
- per_diem_reason: Reason for additional fees
- notes: Internal notes field

Extended workflow states to match spreadsheet process:
- in_progress, pos_confirmed, freight_notified, on_water
- arrival_notice, drayage_confirmed, awaiting_gate_out
- customs_hold, released, delivered, received
- on_hold, ready_to_process, processed

Updated views:
- Reorganized form into notebook tabs
- Added search filters by state
- Added group by options for warehouse, state, etc.
- Badge decorations for state display in list view